### PR TITLE
feat: src变化才设置&删除加载成功log

### DIFF
--- a/src/lazy.ts
+++ b/src/lazy.ts
@@ -106,11 +106,13 @@ export default class Lazy {
    */
   private _setImageSrc(el: HTMLElement, src: string, error?: string, lifecycle?: Lifecycle): void {        
     if ('img' === el.tagName.toLowerCase()) {
-      if (src) el.setAttribute('src', src)
+      if (src){
+        const preSrc = el.getAttribute('src')
+        if(preSrc !== src){
+          el.setAttribute('src', src)
+        }
+      }
       this._listenImageStatus(el as HTMLImageElement, () => {
-        this._log(() => {
-          console.log('Image loaded successfully!')
-        })
         this._lifecycle(LifecycleEnum.LOADED, lifecycle)
       }, () => {
         // Fix onload trigger twice, clear onload event


### PR DESCRIPTION
目前src没有变化的时候也会重设src 导致log反复触发
由于已提供loaded回调，图片加载成功的log个人感觉没有意义，建议删除