### PR TITLE
feat: Only load image if it stays in view

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ You can take advantage of this feature, make different css controls for differen
 </style>
 ```
 
+### Delay loading of images
+
+To avoid loading images that are only shortly visible (e. g. fast scrolling through list of images), a delay in milliseconds can be configured.
+If a delay is set, an image is only loaded if it stays visible for the specified amount of time.
+
+Set delay in object parameter:
+
+```vue
+<template>
+  <img v-lazy="{ src: 'your image url', loading: 'your loading image url', error: 'your error image url', delay: 500 }">
+</template>
+```
+
 ## 📁 Options
 
 |  key   | description  | default | type |
@@ -209,6 +222,7 @@ You can take advantage of this feature, make different css controls for differen
 | observerOptions  | IntersectionObserver options | { rootMargin: '0px', threshold: 0.1 } | [IntersectionObserverInit]([链接地址](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver))|
 | log  | Do not print debug info	 | true  | boolean |
 | lifecycle  | Specify state execution function	 | -  | [Lifecycle](#Lifecycle) |
+| delay  | Time in milliseconds an image has to stay visible before loading starts | 0  | number |
 
 ## ⛱ Lifecycle Hooks
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export interface LazyOptions {
   observerOptions?: IntersectionObserverInit
   log?: boolean
   lifecycle?: Lifecycle
+  delay?: number
 }
 
 export interface ValueFormatterObject {
@@ -11,6 +12,7 @@ export interface ValueFormatterObject {
   error?: string
   loading?: string
   lifecycle?: Lifecycle
+  delay?: number
 }
 
 export enum LifecycleEnum {


### PR DESCRIPTION
This is my take on implementing the feature proposed in #19.

The PR adds a "delay" option that delays loading of the image for the given number of milliseconds. Only if the image stays visible for this amount of time the image gets loaded.

I used this guide to implement this solution: <https://medium.com/ynap-tech/check-if-an-element-is-still-inside-viewport-after-a-given-time-4563d17db6d1>

The idea is that once an observed element is visible instead of directly triggering the image loading a timeout is set and the timeout id is stored as a data attribute in the element. If the element becomes invisible before the timeout the timeout is canceled.